### PR TITLE
Correct typo of "lattitude" to "latitude". Add URL to WebGet debug logging. Allow radar config with style and palette options.

### DIFF
--- a/PiClock3/Astral/Astral.py
+++ b/PiClock3/Astral/Astral.py
@@ -44,7 +44,7 @@ class Astral(Plugin):
         locationInfo = LocationInfo('here', 'here',
                                     self.piclock.timezone().key,
                                     self.piclock.expand(
-                                        self.config.location.lattitude),
+                                        self.config.location.latitude),
                                     self.piclock.expand(self.config.location.longitude))
         s = Weather.sunTimes(now, locationInfo.latitude,
                              locationInfo.longitude, locationInfo.timezone)

--- a/PiClock3/Astral/config.yaml
+++ b/PiClock3/Astral/config.yaml
@@ -5,5 +5,5 @@ format: "{language.sunrise} {plugin-data.sunrise:%H:%M} {language.sunset} {plugi
 # above has no time to put in and would print its own braces.
 polar-format: "{plugin-data.sun} {language.moon_phase} {plugin-data.moonphase}"
 location:
-    lattitude: "{location.lattitude}"
+    latitude: "{location.latitude}"
     longitude: "{location.longitude}"

--- a/PiClock3/GoogleMaps/GoogleMaps.py
+++ b/PiClock3/GoogleMaps/GoogleMaps.py
@@ -38,13 +38,18 @@ class GoogleMaps(Plugin):
         zoom = view.zoom
         rsize = frameRect.size()
         if rsize.width() > 640 or rsize.height() > 640:
-            rsize = QSize(rsize.width() / 2, rsize.height() / 2)
+            rsize = QSize(rsize.width() // 2, rsize.height() // 2)
             zoom -= 1
         urlp.append('zoom=' + str(zoom))
         urlp.append('size=' + str(rsize.width()) + 'x' + str(rsize.height()))
-        urlp.append('maptype=hybrid')
+        maptype = 'hybrid'
+        if 'style' in self.config:
+            maptype = self.config['style']
+        if 'style' in radarConfig:
+            maptype = radarConfig['style']
+        urlp.append('maptype=' + maptype)
 
-        mapUrl = 'http://maps.googleapis.com/maps/api/staticmap?' + \
+        mapUrl = 'https://maps.googleapis.com/maps/api/staticmap?' + \
             '&'.join(urlp)
         
         logger.info("googlemaps url %s", safeurl(mapUrl))   

--- a/PiClock3/MapLoop/MapLoop.py
+++ b/PiClock3/MapLoop/MapLoop.py
@@ -19,7 +19,7 @@ from ..Projection import (getCorners, getPoint, getTileXY, LatLng,
 logger = logging.getLogger(__name__)
 
 # no data source has an opinion about where you live
-DEFAULT_CENTER = {'lattitude': '{location.lattitude}',
+DEFAULT_CENTER = {'latitude': '{location.latitude}',
                   'longitude': '{location.longitude}'}
 DEFAULT_ZOOM = 7
 
@@ -40,7 +40,7 @@ class MapLoop(Plugin):
         c = self.setting('center', self.frameProvider, DEFAULT_CENTER)
         zoom = self.setting('zoom', self.frameProvider, DEFAULT_ZOOM)
         return MapView(
-            LatLng(float(self.piclock.expand(str(c['lattitude']))),
+            LatLng(float(self.piclock.expand(str(c['latitude']))),
                    float(self.piclock.expand(str(c['longitude'])))),
             int(self.piclock.expand(str(zoom))),
             self.region.contentsRect())
@@ -148,7 +148,7 @@ class MapLoop(Plugin):
         markers = self.config.markers if 'markers' in self.config else []
         for marker in markers:
             if 'visible' not in marker or marker['visible'] == 1:
-                loc = LatLng(float(self.piclock.expand(marker["location"]["lattitude"])),
+                loc = LatLng(float(self.piclock.expand(marker["location"]["latitude"])),
                              float(self.piclock.expand(marker["location"]["longitude"])))
                 pt = getPoint(
                     loc, self.view.center, self.view.zoom,

--- a/PiClock3/Metar/Metar.py
+++ b/PiClock3/Metar/Metar.py
@@ -145,7 +145,7 @@ class Metar(Plugin):
         """was the sun up over the station when it reported"""
         return Weather.daytime(
             when,
-            self.piclock.expand(self.piclock.config.location.lattitude),
+            self.piclock.expand(self.piclock.config.location.latitude),
             self.piclock.expand(self.piclock.config.location.longitude),
             self.piclock.timezone().key)
 

--- a/PiClock3/OpenMeteo/OpenMeteo.py
+++ b/PiClock3/OpenMeteo/OpenMeteo.py
@@ -128,7 +128,7 @@ class OpenMeteo(Plugin):
             '&temperature_unit=celsius&wind_speed_unit=kmh'
             '&timezone=%s&forecast_days=%d'
             % (HOST,
-               self.piclock.expand(self.config.location.lattitude),
+               self.piclock.expand(self.config.location.latitude),
                self.piclock.expand(self.config.location.longitude),
                self.piclock.timezone().key,
                int(self.config['forecast-days'])))

--- a/PiClock3/OpenMeteo/config.yaml
+++ b/PiClock3/OpenMeteo/config.yaml
@@ -10,5 +10,5 @@ forecast-days: 9
 
 # the place the clock is pointed at
 location:
-    lattitude: "{location.lattitude}"
+    latitude: "{location.latitude}"
     longitude: "{location.longitude}"

--- a/PiClock3/WebGet.py
+++ b/PiClock3/WebGet.py
@@ -36,7 +36,7 @@ class WebGet(QObject):
     #    logger.debug("delete of WebGet Object %s", self.url)
 
     def finished(self):
-        logger.debug("WebGet Finished")
+        logger.debug(f"WebGet Finished: {safeurl(self.url)}")
         request = self.reply.request()
         if self.reply.error() != QNetworkReply.NoError:
             self.callback(self.reply.error(), None, self.params)

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -1,6 +1,6 @@
 pages:
   clock-page: {order: 0, layout: classic, theme: circuit}
-  maps-page:  {order: 1, layout: bigmaps, theme: stag}
+  maps-page:  {order: 1, layout: bigmaps, theme: circuit}
 
 # the words the clock speaks - one of the codes a language file
 # answers to.  Files ship in PiClock3/languages; a languages/ folder
@@ -8,7 +8,7 @@ pages:
 language: en
 
 location:
-  lattitude: 45
+  latitude: 45
   longitude: -93
   # Blank means the machine's own zone, which is right when the clock
   # sits where it is pointed.  Name a zone when it does not.
@@ -64,18 +64,22 @@ widgets:
   current-conditions:
     plugin: PiClock3.CurrentConditions
     region: current
-    conditions-provider: metar
+    conditions-provider: metar  # or openmeteo
 
   radar1:
     plugin: PiClock3.MapLoop
     region: maps.1
+    style: mapbox/satellite-streets-v10
     zoom: 7
+    palette: 6
+    smooth: 1
+    snow: 1
     center:
-      lattitude: '{location.lattitude}'
+      latitude: '{location.latitude}'
       longitude: '{location.longitude}'
     markers:
       - location:
-          lattitude: '{location.lattitude}'
+          latitude: '{location.latitude}'
           longitude: '{location.longitude}'
         color: red
         size: large
@@ -84,13 +88,17 @@ widgets:
   radar2:
     plugin: PiClock3.MapLoop
     region: maps.2
+    style: mapbox/satellite-streets-v10
     zoom: 11
+    palette: 6
+    smooth: 1
+    snow: 1
     center:
-      lattitude: '{location.lattitude}'
+      latitude: '{location.latitude}'
       longitude: '{location.longitude}'
     markers:
       - location:
-          lattitude: '{location.lattitude}'
+          latitude: '{location.latitude}'
           longitude: '{location.longitude}'
         color: green
         size: medium
@@ -99,17 +107,25 @@ widgets:
   radar3:
     plugin: PiClock3.MapLoop
     region: radars.1
+    style: mapbox/satellite-streets-v10
     zoom: 7
+    palette: 6
+    smooth: 1
+    snow: 1
     center:
-      lattitude: '{location.lattitude}'
+      latitude: '{location.latitude}'
       longitude: '{location.longitude}'
 
   radar4:
     plugin: PiClock3.MapLoop
     region: radars.2
+    style: mapbox/satellite-streets-v10
     zoom: 11
+    palette: 6
+    smooth: 1
+    snow: 1
     center:
-      lattitude: '{location.lattitude}'
+      latitude: '{location.latitude}'
       longitude: '{location.longitude}'
 
 folders:


### PR DESCRIPTION
1. Correct typo of "lattitude" to "latitude" everywhere and in `examples/default.yaml` 
    - You will have to update other example configs

2. Add style, palette, smooth, and snow options to radar config settings in `examples/default.yaml` 
    - You will have to update other example configs
    - `style` will set the MapBox map style or Google map type

3. Correct theme for both pages to be consistent in `examples/default.yaml` 
    - Some of the other example configs have the same problem

4. Add URL to WebGet debug logging for more clarity

5. Update GoogleMaps.py to enhance map type options
    - Add support for configurable map type in self.config and radarConfig. 
    - Update map URL to use HTTPS for improved security.
    - Replace single slashes with integer division to avoid error with QSize() because it expects integers.

