### PR TITLE
Update themes in digital.yaml and gallery.yaml

### DIFF
--- a/examples/digital.yaml
+++ b/examples/digital.yaml
@@ -11,7 +11,7 @@
 # of the region a widget sits in, and the page is not the same height.
 pages:
   clock-page: {order: 0, layout: classic, theme: circuit}
-  maps-page:  {order: 1, layout: bigmaps, theme: stag}
+  maps-page:  {order: 1, layout: bigmaps, theme: circuit}
 
 # the words the clock speaks - one of the codes a language file
 # answers to.  Files ship in PiClock3/languages; a languages/ folder

--- a/examples/gallery.yaml
+++ b/examples/gallery.yaml
@@ -12,7 +12,7 @@
 # slideshow follows from which theme each one names.
 pages:
   clock-page: {order: 0, layout: classic, theme: gallery}
-  maps-page:  {order: 1, layout: bigmaps, theme: stag}
+  maps-page:  {order: 1, layout: bigmaps, theme: gallery}
 
 # the words the clock speaks - one of the codes a language file
 # answers to.  Files ship in PiClock3/languages; a languages/ folder


### PR DESCRIPTION
Standardize themes by changing maps-page to use 'circuit' and 'gallery' themes, respectively. This aligns with the associated page layouts and improves consistency across configuration files.